### PR TITLE
Please pull to fix master branch

### DIFF
--- a/plugin/csscomb.vim
+++ b/plugin/csscomb.vim
@@ -13,4 +13,4 @@ function! g:CSScomb(count, line1, line2)
     call setline(a:line1, lines)
 endfunction
 
-command! -nargs=? -range=% CSScomb :call g:CSSсomb(<count>, <line1>, <line2>, <f-args>)
+command! -nargs=? -range=% CSScomb :call g:CSScomb(<count>, <line1>, <line2>, <f-args>)


### PR DESCRIPTION
This fixes the error introduces by 8ab1732ab23958364ca6e426f37e9748d971caac when calling the CSScomb command.

:CSScomb

E107: Parenthèses manquantes : g:CSSсomb(-1, 1, 4, )

It says "missing parenthesis".

The css is:
# test {

```
margin: auto;
background-position: top;
```

}

My guess is that an invisible caracter has been written on that line. So I retyped it and it fixes the issue.

Regards,
Yann
