### PR TITLE
Fix vim configuration for auto-combing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ Vim command:
 " Map bc to run CSScomb. bc stands for beautify css
 autocmd FileType css noremap <buffer> <leader>bc :CSScomb<CR>
 " Automatically comb your CSS on save
-autocmd BufWritePre,FileWritePre *.css,*.less,*.scss,*.sass silent! :CSScomb<CR>
+autocmd BufWritePre,FileWritePre *.css,*.less,*.scss,*.sass silent! :CSScomb
 ```


### PR DESCRIPTION
I couldn't get the auto-comb config working until I removed the `<CR>` after the `:CSScomb` command.

Some resource for more info:
http://learnvimscriptthehardway.stevelosh.com/chapters/12.html

```
The final part of the command is the command we want to run when the event fires. This is pretty self-explanatory, except for one catch: you can't use special characters like <cr> in the command. 
```
