### PR TITLE
Delete and append instead of setline, to prevent bug when result line…

### DIFF
--- a/plugin/csscomb.vim
+++ b/plugin/csscomb.vim
@@ -16,7 +16,9 @@ function! g:CSScomb(count, line1, line2)
         echoerr split(systemOutput, "\n")[1]
     else
         let lines = readfile(tempFile)
-        call setline(a:line1, lines)
+        exec a:line1.",".a:line2."delete"
+        let a:line0 = a:line1-1
+        call append(a:line0, lines)
     endif
 endfunction
 

--- a/plugin/csscomb.vim
+++ b/plugin/csscomb.vim
@@ -11,7 +11,7 @@ function! g:CSScomb(count, line1, line2)
 
     let tempFile = tempname() . '.' . &filetype
     call writefile(content, tempFile)
-    let systemOutput = system('csscomb -c ~/.csscomb.json' . shellescape(tempFile))
+    let systemOutput = system('csscomb -c ~/.csscomb.json ' . shellescape(tempFile))
     if len(systemOutput)
         echoerr split(systemOutput, "\n")[1]
     else

--- a/plugin/csscomb.vim
+++ b/plugin/csscomb.vim
@@ -11,7 +11,7 @@ function! g:CSScomb(count, line1, line2)
 
     let tempFile = tempname() . '.' . &filetype
     call writefile(content, tempFile)
-    let systemOutput = system('csscomb ' . shellescape(tempFile))
+    let systemOutput = system('csscomb -c ~/.csscomb.json' . shellescape(tempFile))
     if len(systemOutput)
         echoerr split(systemOutput, "\n")[1]
     else


### PR DESCRIPTION
When the lines after combing are fewer than before combing, the extra lines remain in the buffer and mess up the file. e.g. 

> .format {
>    width: 100px;
>    height: 200px;
> 
>    border: 2px solid blue;
> }

will result to this:

> .format {
>    width: 100px;
>    height: 200px;
>    border: 2px solid blue;
> }
> }

By deleting the lines and then appending, this doesn't happen and the result is correct.
